### PR TITLE
Make htmllint a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
 	"main": "./src/index.js",
 	"dependencies": {
 		"gulp-util": "^3.0.6",
-		"htmllint": "^0.2.6",
 		"through2": "^2.0.0"
+	},
+	"peerDependencies": {
+		"htmllint": "^0.2.6"
 	},
 	"devDependencies": {
 		"gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"gulp": "^3.9.0",
 		"gulp-eslint": "^1.0.0",
 		"gulp-mocha": "^2.1.3",
-		"chai": "^3.3.0"
+		"chai": "^3.3.0",
+		"htmllint": "^0.2.6"
 	},
 	"scripts": {
 		"test": "./node_modules/gulp/bin/gulp.js test"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"htmllint": "^0.2.6"
 	},
 	"scripts": {
-		"test": "./node_modules/gulp/bin/gulp.js test"
+		"test": "gulp test"
 	},
 	"bugs": {
 		"url": "https://github.com/yvanavermaet/gulp-htmllint/issues"


### PR DESCRIPTION
Make htmllint a peerDependency to be able to upgrade htmllint without upgrading gulp-htmllint