### PR TITLE
Add the property htmllint to the file object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Release History
 ---------------
+### v0.0.10
+* Add the property htmllint to the file object
 
 ### v0.0.9
 * Add 'rules'-option to pass htmllint options directly

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Boolean value to define if the process should exit with a code of 1 on htmllint 
 
 The custom reporter is a function which accepts 2 parameters: filepath and an array of issues as returned by the htmlling-plugin.
 
+## Results
+
+Add the property htmllint to the file object, which is available to streams that follow the htmllint stream. The property htmllint has the following format:
+
+```js
+{
+	"success": false, // or true for passing htmllint successfully
+	"issues": [] // an array of issues as returned by htmllint
+}
+```
+
 [npm-url]: https://www.npmjs.com/package/gulp-htmllint
 [npm-image]: https://badge.fury.io/js/gulp-htmllint.svg
 [travis-url]: https://travis-ci.org/yvanavermaet/gulp-htmllint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-htmllint",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Check HTML code style with htmllint",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
Add the property htmllint to the file object, which is available to streams that follow the htmllint stream.
With this addition, one can has more control to the following stream base on the result of htmllint.
Gulp-eslint and gulp-csslint both has counterpart property added to the file object, and the name of the properties are eslint and csslint.
When I use this three lint in my project, I fount it hard to realize some specify requirement if gulp-htmllint does not has the property addition, while the other two can.
So I add it, and I think this is a necessary addition, which extent the function of the plugin, so I hope it will benefit more people who use the plugin.
