### PR TITLE
Updating htmllint dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Release History
 ---------------
 
+### v0.0.10
+* Update htmllint dependency
+
 ### v0.0.9
 * Add 'rules'-option to pass htmllint options directly
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"main": "./src/index.js",
 	"dependencies": {
 		"gulp-util": "^3.0.7",
-		"htmllint": "^0.3.0",
+		"htmllint": "^0.4.0",
 		"through2": "^2.0.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-htmllint",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Check HTML code style with htmllint",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
htmllint recently released version 0.4.0 update which includes the following changes:
* add "allownull" as an option for `img-req-alt`
* add `class-no-dup` option
* allow inline configurations to use - and _ interchangeably
* add "smart" as an option for `doctype-first`
* update dependencies
* add `tag-close` option
* add `indent-width-cont` option