### PR TITLE
Resolved gulp doesn't finish for lint reject

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ module.exports = function(options, reporter) {
 			cb(null, file);
 		}).catch(function(error) {
 			out.push('\n' + file.path + '\n' + gutil.colors.red(error.toString()));
+			cb(null, file);
 		});
 	}, function(cb) {
 		if (out.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,7 @@ module.exports = function(options, reporter) {
 		}).catch(function(error) {
 			out.push('\n' + file.path + '\n' + gutil.colors.red(error.toString()));
 			cb(null, file);
+			process.exit(1);
 		});
 	}, function(cb) {
 		if (out.length > 0) {


### PR DESCRIPTION
When html lint promise reject due to html failures, the gulp task doesn't complete with error code. 

I have resolved it to add the callback function in the catch.