### PR TITLE
Use `configPath` for error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function getOptions(options) {
 			try {
 				htmllintOptions = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 			} catch (e) {
-				fancyLog(colors.red('Could not process .htmllintrc'));
+				fancyLog(colors.red('Could not process ' + configPath));
 			}
 		}
 	}


### PR DESCRIPTION
When passing a custom file name and an error happens, it is not obvious that the custom file is used as `.htmllintrc` was hard coded.