### PR TITLE
Add default reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,8 +86,7 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
@@ -321,6 +320,31 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
 		},
+		"cliui": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+			"integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+			"requires": {
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"wrap-ansi": "2.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
 		"clone": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
@@ -338,6 +362,11 @@
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"color-convert": {
 			"version": "1.9.1",
@@ -1918,8 +1947,7 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "http://artifactory.persgroep.cloud/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "2.0.1",
@@ -2424,6 +2452,11 @@
 			"requires": {
 				"path-key": "2.0.1"
 			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"object-assign": {
 			"version": "3.0.0",
@@ -2972,7 +3005,6 @@
 			"version": "2.1.1",
 			"resolved": "http://artifactory.persgroep.cloud/artifactory/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -2981,14 +3013,12 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "http://artifactory.persgroep.cloud/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "http://artifactory.persgroep.cloud/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -3005,7 +3035,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "2.1.1"
 			}
@@ -3279,6 +3308,35 @@
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"requires": {
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	"main": "./src/index.js",
 	"dependencies": {
 		"ansi-colors": "^1.0.1",
+		"cliui": "^4.0.0",
 		"fancy-log": "^1.3.2",
 		"htmllint": "^0.7.0",
 		"plugin-error": "^0.1.2",

--- a/src/default-reporter.js
+++ b/src/default-reporter.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var colors = require('ansi-colors'),
+	cliui = require('cliui'),
+	fancyLog = require('fancy-log'),
+	UI_WIDTH = 120;
+
+function generateOutput(filepath, issues) {
+	var errors,
+		header = colors.bold(colors.underline(colors.white(filepath + ':'))),
+		footer = colors.red('Found' + issues.length + 'errors'),
+		ui = cliui({
+			'width': UI_WIDTH
+		});
+
+	errors = issues.map(function(issue) {
+		var location = colors.dim('[' + issue.line + ':' + issue.column + ']');
+
+		return location + '\t  ' + issue.msg + '\t  ' + colors.dim(issue.rule);
+	}).join('\n');
+
+	ui.div(header + '\n' + errors + '\n' + footer + '\n');
+
+	return ui.toString();
+}
+
+function report(filepath, issues) {
+	if (issues.length > 0) {
+		fancyLog(generateOutput(filepath, issues));
+		// eslint-disable-next-line no-undef
+		process.exitCode = 1;
+	}
+}
+
+module.exports = {
+	'generateOutput': generateOutput,
+	'report': report
+};

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ var fs = require('fs'),
 	fancyLog = require('fancy-log'),
 	PluginError = require('plugin-error'),
 	htmllint = require('htmllint'),
-	through = require('through2');
+	through = require('through2'),
+	defaultReporter = require('./default-reporter').report;
 
 function getOptions(options) {
 	var htmllintOptions = {},
@@ -35,7 +36,7 @@ function getPlugins(options) {
 	return options.plugins || [];
 }
 
-function lintFiles(options, reporter) {
+function lintFiles(options, customReporter) {
 	var out = [],
 		errorCount = 0;
 
@@ -76,16 +77,10 @@ function lintFiles(options, reporter) {
 			file.htmllint.success = issues.length === 0;
 			file.htmllint.issues = issues;
 
-			if (typeof reporter === 'function') {
-				reporter(file.path, issues);
+			if (typeof customReporter === 'function') {
+				customReporter(file.path, issues);
 			} else {
-				if (issues.length > 0) {
-					out.push('\n' + file.path);
-				}
-
-				issues.forEach(function(issue) {
-					out.push(colors.red('line ' + issue.line + '\tcol ' + issue.column + '\t' + issue.msg + ' (' + issue.code + ')'));
-				});
+				defaultReporter(file.path, issues);
 			}
 
 			cb();

--- a/test/default-reporter.js
+++ b/test/default-reporter.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var issues = require('./fixtures/issues.json'),
+	filepath = '/some/path/to/html',
+	expect = require('chai').expect;
+
+describe('default-reporter', function() {
+	var defaultReporter = require('../src/default-reporter').generateOutput;
+
+	it('returns "no errors" message when there are no issues', function(done) {
+		var result = defaultReporter('', []);
+
+		expect(result).be.equal('\u001b[1m\u001b[4m\u001b[37m:\u001b[39m\u001b[24m\u001b[22m\n\n\u001b[31mFound0errors\u001b[39m\n');
+
+		return done();
+	});
+
+	it('returns formatted error message when issues are given', function(done) {
+		var result = defaultReporter(filepath, issues);
+
+		expect(result).to.be.equal('\u001b[1m\u001b[4m\u001b[37m/some/path/to/html:\u001b[39m\u001b[24m\u001b[22m\n\u001b[2m[11:7]\u001b[22m  line ending does not match format: lf                    \u001b[2mline-end-style\u001b[22m\n\u001b[2m[7:13]\u001b[22m  class value must match the format: underscore            \u001b[2mclass-style\u001b[22m\n\u001b[2m[7:7]\u001b[22m   duplicate attribute: class                               \u001b[2mattr-no-dup\u001b[22m\n\u001b[31mFound3errors\u001b[39m\n');
+
+		return done();
+	});
+});

--- a/test/fixtures/issues.json
+++ b/test/fixtures/issues.json
@@ -1,0 +1,34 @@
+[
+  {
+    "line": 11,
+    "column": 7,
+    "code": "E015",
+    "data": {
+      "format": "lf"
+    },
+    "rule": "line-end-style",
+    "msg": "line ending does not match format: lf"
+  },
+  {
+    "line": 7,
+    "column": 13,
+    "code": "E011",
+    "data": {
+      "attribute": "class",
+      "format": "underscore",
+      "value": "page-title"
+    },
+    "rule": "class-style",
+    "msg": "class value must match the format: underscore"
+  },
+  {
+    "line": 7,
+    "column": 7,
+    "code": "E003",
+    "data": {
+      "attribute": "class"
+    },
+    "rule": "attr-no-dup",
+    "msg": "duplicate attribute: class"
+  }
+]


### PR DESCRIPTION
This proposed PR is to add a separate default reporter module. With it the formatting is changed to follow in the footsteps of sass lint output. It's a little bit easier to parse when looking at the errors. 

TODO: Update Documentation to reflect changes if accepted